### PR TITLE
fix marker

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,7 @@ export function GetKeyAtPositionInDocument(position: vscode.Position, document: 
     const ii = ltext.lastIndexOf('.instant(');
     const gi = ltext.lastIndexOf('.get(');
     const vi = ltext.lastIndexOf('getI18nValue(');
-    const mi = ltext.lastIndexOf('.marker(');
+    const mi = ltext.lastIndexOf('marker(');
 
     if (!(ii > -1 || gi > -1 || vi > -1 || mi > -1)) {
       return { clickedKey: '', range: undefined };


### PR DESCRIPTION
Sorry, messed up last time, `marker` is imported, not accessed from an object, so no need for the `.`

Still couldn't test it locally, so if you can, please check if it works correctly:

simply

```ts
import { marker } from '@biesbjerg/ngx-translate-extract-marker';
marker('Extract me');
```